### PR TITLE
preferences save fix/rehaul

### DIFF
--- a/server/compatibility.cs
+++ b/server/compatibility.cs
@@ -8,6 +8,14 @@ if(isFile("Add-Ons/System_oRBs/hooks/serverControl.cs"))
 	exec("Add-Ons/System_oRBs/hooks/serverControl.cs");
 $ORBS::Hooks::ServerControl = true; // yup oRBs too
 
+if(!isFile("Add-Ons/System_ReturnToBlockland/server.cs")) { // the addon does not need to be *valid*, the server.cs just needs to exist
+	%file = new FileObject();
+	%file.openForWrite("Add-Ons/System_ReturnToBlockland/server.cs");
+	%file.writeLine("// This is an empty, fake RTB folder so that RTB prefs will load.");
+	%file.close();
+	%file.delete();
+}
+
 package BLPrefCompatibilityPackage {
 	function RTB_registerPref(%name, %addon, %variable, %params, %file, %default, %requiresRestart, %hostOnly, %callback) {
 		if(isFunction("RTB_registerPref")) {

--- a/server/handshake.cs
+++ b/server/handshake.cs
@@ -26,6 +26,7 @@ package BLPrefServerPackage {
 			activatePackage(BLPrefServerPackage);
 			activatePackage(BLPrefCompatibilityPackage);
 			activatePackage(BLPrefBL_IDPackage);
+			activatePackage(BLPrefSaveLoadPackage);
 		}
 	}
 };

--- a/server/interaction.cs
+++ b/server/interaction.cs
@@ -70,7 +70,7 @@ function serverCmdUpdatePref(%client, %varname, %newvalue, %announce) {
 		%pso.updateValue(%newvalue, %client);
 
 		if($Pref::BLPrefs::ServerDebug) {
-			echo("\c4" @ %client.name @ "(BL_ID: " @ %client.bl_id @ ") set " @ %varname @ " to " @ %newvalue);
+			echo("\c4" @ %client.name @ " (BL_ID: " @ %client.bl_id @ ") set " @ %varname @ " to " @ %newvalue);
 		}
 
 		if(%announce) {
@@ -92,6 +92,8 @@ function serverCmdUpdatePref(%client, %varname, %newvalue, %announce) {
 				commandToClient(%cl, 'updateBLPref', %varname, %newvalue);
 			}
 		}
+		
+		saveBLPreferences();
 	} else {
 		//so they tried to update a variable that doesn't exist...
 		warn("Variable \"" @ %varname @ "\" doesn't exist!");


### PR DESCRIPTION
all preferences now save properly and are moved to a prefs.cs file located in config/server/BLPrefs - **any** pref that is registered via registerPref() is now sent to the aforementioned file to be saved (excluding default server prefs such as ::Name as those are exported normally).

prefs also now save immediately as they are updated via the GUI as opposed to waiting until the server is shutdown appropriately (it will still do this, however).

also fixed a minor global pref typo.

and finally, a fake RTB folder/server.cs is made in the absence of a RTB server.cs - does not interfere with RTB any way when installed afterward.

_tested extensively on both a non-dedicated server and a dedicated server with no issues found._
